### PR TITLE
게시판 서비스 뷰에 기능 구현하기 - 댓글 서비스 구현

### DIFF
--- a/src/main/java/fastcampus/board/service/ArticleCommentService.java
+++ b/src/main/java/fastcampus/board/service/ArticleCommentService.java
@@ -1,14 +1,18 @@
 package fastcampus.board.service;
 
+import fastcampus.board.domain.ArticleComment;
 import fastcampus.board.dto.ArticleCommentDto;
 import fastcampus.board.repository.ArticleCommentRepository;
 import fastcampus.board.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -18,21 +22,33 @@ public class ArticleCommentService {
     private final ArticleCommentRepository articleCommentRepository;
 
     public List<ArticleCommentDto> searchArticleComments(Long articleId) {
-        return List.of();
+        return articleCommentRepository.findByArticle_Id(articleId)
+                .stream()
+                .map(ArticleCommentDto::from)
+                .toList();
     }
 
     @Transactional
     public void saveArticleComment(ArticleCommentDto dto) {
-
+        try {
+            articleCommentRepository.save(dto.toEntity(articleRepository.getReferenceById(dto.articleId())));
+        } catch (EntityNotFoundException e) {
+            log.warn("댓글 저장 실패. 댓글의 게시글을 찾을 수 없습니다 - dto: {}", dto);
+        }
     }
 
     @Transactional
     public void updateArticleComment(ArticleCommentDto dto) {
-
+        try {
+            ArticleComment articleComment = articleCommentRepository.getReferenceById(dto.id());
+            if(dto.content() != null) {articleComment.setContent(dto.content());}
+        } catch (EntityNotFoundException e) {
+            log.warn("댓글 업데이트 실패. 댓글을 찾을 수 없습니다 - dto: {}", dto);
+        }
     }
 
     @Transactional
     public void deleteArticleComment(Long articleCommentId) {
-
+        articleCommentRepository.deleteById(articleCommentId);
     }
 }


### PR DESCRIPTION
테스트 케이스를 통과하도록 비지니스 로직(CRUD) 구현

-  구현한 테스트 목록
  - 게시글 Id로 조회시 해당 댓글 리스트 반환
  - 댓글 정보를 입력시 댓글 저장
  - 댓글 저장을 시도했는데 맞는 게시글이 없으면, 경고 로그를 찍고 아무것도 안함.
  - 댓글 정보 입력시 댓글 수정
  - 없는 댓글 정보를 수정하려고 하면 경고 로그를 찍고 아무것도 안함.
  - 댓글 Id 입력시 댓글 삭제

this closes #31 