### PR TITLE
뷰 - 페이지네이션, 정렬 연결

### DIFF
--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -57,6 +57,7 @@
             <attr sel="li[0]/a"
                   th:text="'previous'"
                   th:href="@{/articles(page=${articles.number - 1},
+                  sort=${param.sort},
                   searchType=${param.searchType},
                   searchValue=${param.searchValue})}"
                   th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
@@ -65,6 +66,7 @@
                 <attr sel="a"
                       th:text="${pageNumber + 1}"
                       th:href="@{/articles(page=${pageNumber},
+                      sort=${param.sort},
                       searchType=${param.searchType},
                       searchValue=${param.searchValue})}"
                       th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
@@ -73,6 +75,7 @@
             <attr sel="li[2]/a"
                   th:text="'next'"
                   th:href="@{/articles(page=${articles.number + 1},
+                  sort=${param.sort},
                   searchType=${param.searchType},
                   searchValue=${param.searchValue})}"
                   th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"

--- a/src/main/resources/templates/articles/search-hashtag.th.xml
+++ b/src/main/resources/templates/articles/search-hashtag.th.xml
@@ -59,6 +59,7 @@
                       th:text="'previous'"
                       th:href="@{/articles(
                       page=${articles.number - 1},
+                      sort=${param.sort},
                       searchType=${searchType.name},
                       searchValue=${param.searchValue})}"
                       th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
@@ -68,6 +69,7 @@
                           th:text="${pageNumber + 1}"
                           th:href="@{/articles(
                           page=${pageNumber},
+                          sort=${param.sort},
                           searchType=${searchType.name},
                           searchValue=${param.searchValue})}"
                           th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
@@ -77,6 +79,7 @@
                       th:text="'next'"
                       th:href="@{/articles(
                       page=${articles.number + 1},
+                      sort=${param.sort},
                       searchType=${searchType.name},
                       searchValue=${param.searchValue})}"
                       th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"


### PR DESCRIPTION
페이지네이션과 정렬 연동이 안되어있어서 페이지를 넘기면 sort결과가 초기화되는 현상 발생

정렬결과를 유지하기 위해 페이지네이션 수정

this closes #38 