### PR TITLE
[리팩토링] AuditingFields 의 잘못 표현된 부분 개선

### DIFF
--- a/src/main/java/fastcampus/board/domain/AuditingFields.java
+++ b/src/main/java/fastcampus/board/domain/AuditingFields.java
@@ -23,18 +23,18 @@ public abstract class AuditingFields {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @CreatedBy
     @Column(nullable = false, length = 100, updatable = false)
-    private String createdBy;
+    protected String createdBy;
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime modifiedAt;
+    protected LocalDateTime modifiedAt;
 
     @LastModifiedBy
     @Column(nullable = false, length = 100)
-    private String modifiedBy;
+    protected String modifiedBy;
 }


### PR DESCRIPTION
이 pr은 AuditingFields의 필드 접근제어자를 추상 클래스에 맞게 protected로 수정한다.
이는 인증이 없는 상태에서 정보를 기록해야 할 때 필요할 예정.
대표적인 사례는 회원 가입.

This closes #71 