### PR TITLE
[고도화] Swagger UI 로 API 문서화하기 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
+//    implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.12'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -38,6 +40,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 


### PR DESCRIPTION
* 간단한 의존성 추가만으로 즉시 스웨거 문서화가 진행됨
이 때 Spring Data Rest 가  만들어 준 api를 자동으로
스웨거에 노출시키기 위해 추가 의존성을 사용함
---
(http://localhost:8080/swagger-ui/index.html

this closes #79 