### PR TITLE
[고도화] 해시태그 검색시 조회 쿼리 최적화

### DIFF
--- a/src/main/java/fastcampus/board/dto/ArticleDto.java
+++ b/src/main/java/fastcampus/board/dto/ArticleDto.java
@@ -46,14 +46,14 @@ public record ArticleDto(
         );
     }
 
-    public static ArticleDto from(ArticleSelectDto selectDto, Set<Hashtag> hashtags) {
+    public static ArticleDto from(ArticleSelectDto selectDto, Set<String> hashtagNames) {
         return ArticleDto.of(
                 selectDto.id(),
                 UserAccountDto.from(selectDto.userAccount()),
                 selectDto.title(),
                 selectDto.content(),
-                hashtags.stream()
-                        .map(HashtagDto::from)
+                hashtagNames.stream()
+                        .map(hashtagName -> HashtagDto.from(hashtagName))
                         .collect(Collectors.toUnmodifiableSet()),
                 selectDto.createdAt(),
                 selectDto.createdBy(),

--- a/src/main/java/fastcampus/board/dto/HashtagDto.java
+++ b/src/main/java/fastcampus/board/dto/HashtagDto.java
@@ -35,6 +35,10 @@ public record HashtagDto(
         );
     }
 
+    public static HashtagDto from(String hashtagName) {
+        return HashtagDto.of(hashtagName);
+    }
+
     public Hashtag toEntity() {
         return Hashtag.of(hashtagName);
     }

--- a/src/main/java/fastcampus/board/dto/query/ArticleSelectDto.java
+++ b/src/main/java/fastcampus/board/dto/query/ArticleSelectDto.java
@@ -11,6 +11,7 @@ public record ArticleSelectDto (
         UserAccount userAccount,
         String title,
         String content,
+        String hashtagName,
         LocalDateTime createdAt,
         String createdBy,
         LocalDateTime modifiedAt,

--- a/src/main/java/fastcampus/board/repository/querydsl/ArticleHashtagRepositoryImpl.java
+++ b/src/main/java/fastcampus/board/repository/querydsl/ArticleHashtagRepositoryImpl.java
@@ -45,6 +45,7 @@ public class ArticleHashtagRepositoryImpl extends QuerydslRepositorySupport impl
                         article.userAccount,
                         article.title,
                         article.content,
+                        hashtag.hashtagName,
                         article.createdAt,
                         article.createdBy,
                         article.modifiedAt,


### PR DESCRIPTION
article과 hashtag의 연관관계를 articleHashtag 테이블이 갖게 되면서, article 조회시 hashtag를 가져오는 쿼리가 각 article마다 나가게 되어서 N+1문제가 발생하였다.

이를 해결하기 위해서 연관된 articleHashtag를 모두 가져와, articleDTO로 변환하는 로직을 추가하였음.

this closes #87 