### PR TITLE
[어드민] article 필드의 userAccount의 fetch방식을 LAZY -> EAGER 변경

### DIFF
--- a/src/main/java/fastcampus/board/domain/Article.java
+++ b/src/main/java/fastcampus/board/domain/Article.java
@@ -25,7 +25,8 @@ public class Article extends AuditingFields{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter @ManyToOne(optional = false, fetch = FetchType.LAZY) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
+    //TODO: Hal Explorer(api)를 사용하기 위해 fetch방식을 EAGER로 변경. 추후 api 제공방식을 변경하여 지연로딩으로 변경하자.
+    @Setter @ManyToOne(optional = false, fetch = FetchType.EAGER) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
     @Setter @Column(nullable = false, length = 255) private String title;
     @Setter @Column(nullable = false, length = 10000) private String content;
 


### PR DESCRIPTION
어드민 프로젝트에서 HAL explorer api를 사용하기 위함.

this closes #94 