### PR TITLE
[어드민] fetch방식을 LAZY -> EAGER 변경

### DIFF
--- a/src/main/java/fastcampus/board/domain/ArticleComment.java
+++ b/src/main/java/fastcampus/board/domain/ArticleComment.java
@@ -26,8 +26,9 @@ public class ArticleComment extends AuditingFields{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter @ManyToOne(optional = false, fetch = FetchType.LAZY) private Article article;
-    @Setter @ManyToOne(optional = false, fetch = FetchType.LAZY) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
+    //TODO: Hal Explorer(api)를 사용하기 위해 fetch방식을 EAGER로 변경. 추후 api 제공방식을 변경하여 지연로딩으로 변경하자.
+    @Setter @ManyToOne(optional = false, fetch = FetchType.EAGER) private Article article;
+    @Setter @ManyToOne(optional = false, fetch = FetchType.EAGER) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
 
     @Setter @Column(updatable = false) private Long parentCommentId;
 

--- a/src/main/java/fastcampus/board/domain/ArticleHashtag.java
+++ b/src/main/java/fastcampus/board/domain/ArticleHashtag.java
@@ -18,11 +18,13 @@ public class ArticleHashtag extends AuditingFields{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = {PERSIST, MERGE})
+    //TODO: Hal Explorer(api)를 사용하기 위해 fetch방식을 EAGER로 변경. 추후 api 제공방식을 변경하여 지연로딩으로 변경하자.
+    @ManyToOne(fetch = FetchType.EAGER, cascade = {PERSIST, MERGE})
     @JoinColumn(name = "articleId")
     private Article article;
 
-    @ManyToOne(fetch = FetchType.LAZY,  cascade = {PERSIST, MERGE})
+    //TODO: Hal Explorer(api)를 사용하기 위해 fetch방식을 EAGER로 변경. 추후 api 제공방식을 변경하여 지연로딩으로 변경하자.
+    @ManyToOne(fetch = FetchType.EAGER,  cascade = {PERSIST, MERGE})
     @JoinColumn(name = "hashtagId")
     private Hashtag hashtag;
 


### PR DESCRIPTION
어드민 프로젝트에서 HAL explorer api를 사용하기 위함.
즉시로딩 방식은 매우 위험하므로, api 제공방식을 변경하여 다시 지연로딩으로 변경해야함.

this fixed #94 